### PR TITLE
Dont log first attempt at calling API endpoints - too much log noise

### DIFF
--- a/atomict/api.py
+++ b/atomict/api.py
@@ -8,9 +8,10 @@ from requests.exceptions import (
     ConnectionError,
     Timeout,
 )
-from tenacity import retry, stop_after_attempt, wait_exponential, before_log, after_log, retry_if_exception_type, retry_if_exception, before_sleep_log
+from tenacity import retry, stop_after_attempt, wait_exponential, after_log, retry_if_exception_type, retry_if_exception, before_sleep_log
 
 from atomict.exceptions import APIValidationError, PermissionDenied
+from atomict.utils.tenacity import before_log
 
 
 logger = logging.getLogger(__name__)

--- a/atomict/utils/tenacity.py
+++ b/atomict/utils/tenacity.py
@@ -1,0 +1,36 @@
+
+import typing
+
+from tenacity import _utils
+
+if typing.TYPE_CHECKING:
+    import logging
+
+    from tenacity import RetryCallState
+
+
+def before_log(
+    logger: "logging.Logger", log_level: int
+) -> typing.Callable[["RetryCallState"], None]:
+    """
+    Before call strategy that logs to some logger the attempt.
+
+    This one is a copy of the tenacity.before_log function, but it doesnt log the first
+    attempt because that generates a lot of noise.
+    """
+
+    def log_it(retry_state: "RetryCallState") -> None:
+        if retry_state.fn is None:
+            # NOTE(sileht): can't really happen, but we must please mypy
+            fn_name = "<unknown>"
+        else:
+            fn_name = _utils.get_callback_name(retry_state.fn)
+
+        if retry_state.attempt_number > 1:
+            logger.log(
+                log_level,
+            f"Starting call to '{fn_name}', "
+            f"this is the {_utils.to_ordinal(retry_state.attempt_number)} time calling it.",
+        )
+
+    return log_it


### PR DESCRIPTION
Changing the before_log function so that it doesn't log the first connection attempt but only retries

Before this our logs looks like this:

```
INFO 2024-12-03 04:01:56,546  Uploaded KS_DOS_total.dat OK
INFO 2024-12-03 04:01:56,546  Starting call to 'atomict.api.post', this is the 1st time calling it.
INFO 2024-12-03 04:01:56,650  Starting call to 'atomict.api.post', this is the 1st time calling it.
INFO 2024-12-03 04:01:56,800  Uploaded Cu_l_proj_dos_raw.dat OK
INFO 2024-12-03 04:01:56,800  Starting call to 'atomict.api.post', this is the 1st time calling it.
INFO 2024-12-03 04:01:56,910  Starting call to 'atomict.api.patch', this is the 1st time calling it.
INFO 2024-12-03 04:01:57,056  Starting call to 'atomict.api.post', this is the 1st time calling it.
INFO 2024-12-03 04:01:57,131  Uploaded band1003.out OK
INFO 2024-12-03 04:01:57,132  Starting call to 'atomict.api.post', this is the 1st time calling it.
INFO 2024-12-03 04:01:57,219  Starting call to 'atomict.api.post', this is the 1st time calling it.
INFO 2024-12-03 04:01:57,296  Uploaded band1007.out OK
INFO 2024-12-03 04:01:57,296  Starting call to 'atomict.api.post', this is the 1st time calling it.
INFO 2024-12-03 04:01:57,410  Starting call to 'atomict.api.post', this is the 1st time calling it.
INFO 2024-12-03 04:01:57,486  Uploaded band1001.out OK
INFO 2024-12-03 04:01:57,486  Starting call to 'atomict.api.post', this is the 1st time calling it.
INFO 2024-12-03 04:01:57,595  Starting call to 'atomict.api.post', this is the 1st time calling it.
INFO 2024-12-03 04:01:57,668  Uploaded 2088f43b-f47a-4043-8ca9-306a13fc549f.json OK
INFO 2024-12-03 04:01:57,668  Starting call to 'atomict.api.post', this is the 1st time calling it.
INFO 2024-12-03 04:01:57,777  Starting call to 'atomict.api.post', this is the 1st time calling it.
INFO 2024-12-03 04:01:57,850  Uploaded band1002.out OK
INFO 2024-12-03 04:01:57,851  Starting call to 'atomict.api.post', this is the 1st time calling it.
INFO 2024-12-03 04:01:57,958  Starting call to 'atomict.api.patch', this is the 1st time calling it.
INFO 2024-12-03 04:01:58,101  Starting call to 'atomict.api.patch', this is the 1st time calling it.
```

after this PR it looks like this:
```
INFO 2024-12-03 04:01:56,546  Uploaded KS_DOS_total.dat OK
INFO 2024-12-03 04:01:56,800  Uploaded Cu_l_proj_dos_raw.dat OK
INFO 2024-12-03 04:01:57,131  Uploaded band1003.out OK
INFO 2024-12-03 04:01:57,296  Uploaded band1007.out OK
INFO 2024-12-03 04:01:57,486  Uploaded band1001.out OK
INFO 2024-12-03 04:01:57,668  Uploaded 2088f43b-f47a-4043-8ca9-306a13fc549f.json OK
INFO 2024-12-03 04:01:57,850  Uploaded band1002.out OK
```