### PR TITLE
Add ability to subsample traj files from the commandline

### DIFF
--- a/atomict/cli/commands/traj.py
+++ b/atomict/cli/commands/traj.py
@@ -1,0 +1,57 @@
+import click
+from pathlib import Path
+
+
+try:
+    from ase.io import read, write
+    from ase.io.trajectory import TrajectoryWriter
+except ImportError:
+    click.echo("Error: ASE modules not found. Please install with 'pip install atomict[utils]'")
+    raise
+
+
+@click.group()
+def traj():
+    """Operations on trajectory files."""
+    pass
+
+
+@traj.command()
+@click.argument('file_path', type=click.Path(exists=True))
+@click.option('-s', '--step', type=int, required=True, help='Subsample every Nth frame')
+def subsample(file_path, step):
+    """Subsample a trajectory file by taking every Nth frame.
+    
+    The output will be saved as {original_filename}_subsampled_{step}.traj
+    """
+    if step <= 0:
+        click.echo("Error: Step must be a positive integer")
+        return
+
+    try:
+        # Parse the input file path
+        input_path = Path(file_path)
+        
+        # Read all frames from the trajectory file
+        atoms_list = read(file_path, index=":")
+        
+        # Subsample the frames with the given step
+        subsampled_atoms = atoms_list[::step]
+        
+        if not subsampled_atoms:
+            click.echo("Warning: No frames were selected with the given step size")
+            return
+        
+        # Create output filename
+        stem = input_path.stem
+        output_file = input_path.with_name(f"{stem}_subsampled_{step}.traj")
+        
+        # Write the subsampled trajectory
+        write(str(output_file), subsampled_atoms)
+        
+        click.echo(f"Successfully subsampled trajectory with step {step}")
+        click.echo(f"Wrote {len(subsampled_atoms)} frames to {output_file}")
+        click.echo(f"Original trajectory had {len(atoms_list)} frames")
+        
+    except Exception as e:
+        click.echo(f"Error processing trajectory file: {str(e)}") 

--- a/atomict/cli/main.py
+++ b/atomict/cli/main.py
@@ -9,7 +9,7 @@ from atomict.__version__ import __version__
 from atomict.cli.commands import login, user
 
 # Import command groups
-from .commands import adsorbate, catalysis, k8s, project, task, upload
+from .commands import adsorbate, catalysis, k8s, project, task, traj, upload
 from .commands.exploration import soec, sqs
 from .commands.simulation import fhiaims, kpoint, vibes
 
@@ -106,6 +106,7 @@ cli.add_command(kpoint.kpoint_group)
 cli.add_command(catalysis.catalysis_group)  # WIP
 cli.add_command(sqs.sqs_group)
 cli.add_command(soec.soecexploration_group)
+cli.add_command(traj.traj)
 cli.add_command(user.user_group)
 cli.add_command(login._login)
 cli.add_command(vibes.vibes_group)


### PR DESCRIPTION
I have a bunch of traj files but they are huge, 800MB each:
```
(.venv) alainr@spitfire:/nas/atomict/atomic_cli (alainr/traj-subsample)$ ls -l /home/alainr/2.1/
total 3574572
-rw-rw-r-- 1 alainr alainr 832268514 Apr  1 00:38 WC_supercell_8x8x8_1500K_10000fs_impact_energy_500eV.traj
-rw-rw-r-- 1 alainr alainr 832264930 Apr  1 00:39 WC_supercell_8x8x8_2500K_10000fs_impact_energy_500eV.traj
-rw-rw-r-- 1 alainr alainr 832270071 Apr  1 00:19 WC_supercell_8x8x8_300K_10000fs_impact_energy_500eV.traj
-rw-rw-r-- 1 alainr alainr 832269630 Apr  1 00:22 WC_supercell_8x8x8_800K_10000fs_impact_energy_500eV.traj
```

I want to subsample them, so I can take every Nth frame from the trajectory

This PR allows one to do this:
```
> tess traj subsample /home/alainr/2.1/WC_supercell_8x8x8_1500K_10000fs_impact_energy_500eV.traj -s 4
Successfully subsampled trajectory with step 4
Wrote 2551 frames to /home/alainr/2.1/WC_supercell_8x8x8_1500K_10000fs_impact_energy_500eV_subsampled_4.traj
Original trajectory had 10202 frames
```
and now there's a file there that's 240MB because it only have every 4th frame in it

```
(.venv) alainr@spitfire:/nas/atomict/atomic_cli (alainr/traj-subsample)$ ls -l /home/alainr/nuclear-study/2.1/
total 3574572
-rw-rw-r-- 1 alainr alainr 239914063 Apr  1 01:13 WC_supercell_8x8x8_1500K_10000fs_impact_energy_500eV_subsampled_4.traj
-rw-rw-r-- 1 alainr alainr 832268514 Apr  1 00:38 WC_supercell_8x8x8_1500K_10000fs_impact_energy_500eV.traj
-rw-rw-r-- 1 alainr alainr 832264930 Apr  1 00:39 WC_supercell_8x8x8_2500K_10000fs_impact_energy_500eV.traj
-rw-rw-r-- 1 alainr alainr 832270071 Apr  1 00:19 WC_supercell_8x8x8_300K_10000fs_impact_energy_500eV.traj
-rw-rw-r-- 1 alainr alainr 832269630 Apr  1 00:22 WC_supercell_8x8x8_800K_10000fs_impact_energy_500eV.traj
```