### PR TITLE
fix: Python 3.13 compatibility for installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ description = "The client application for the https://atomictessellator.com/"
 keywords = ["atomic", "tessellator", "cli", "client", "fhi-aims", "kpoint", "sqs"]
 readme = "README.md"
 requires-python = ">=3.10"
-license = { text = "MIT" }
+license = "MIT"
 dynamic = ["version", "dependencies"]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,8 @@ rich~=13.0
 
 # science
 ase>=3.23.0
-spglib==2.5.0
-pymatgen==2025.3.10
+spglib>=2.5.0
+pymatgen>=2025.4.20
 msgpack==1.1.0
 msgpack_numpy==0.4.8
 deepdiff


### PR DESCRIPTION
## Summary
- **`pyproject.toml`**: Changed `license = { text = "MIT" }` to `license = "MIT"` (PEP 621 string format). Newer setuptools on Python 3.13 warns/errors on the table format.
- **`requirements.txt`**: Relaxed `spglib==2.5.0` to `spglib>=2.5.0`. Version 2.5.0 has no pre-built wheel for Python 3.13, and building from source fails due to a `scikit-build-core` license-files parsing bug. Version 2.7.0 ships a 3.13 wheel.
- **`requirements.txt`**: Bumped `pymatgen==2025.3.10` to `pymatgen>=2025.4.20`. Version 2025.3.10 declares `Requires-Python: <3.13`.

## Test plan
- [x] Clean `pip install -e .` on Python 3.13 — all dependencies resolve and install
- [x] 79/80 unit tests pass (1 pre-existing failure in `test_convert.py` unrelated to these changes)
- [x] No breaking changes to existing Python 3.10-3.12 support (minimum versions unchanged or raised to compatible releases)

Coauthored by Claude